### PR TITLE
Please add module and threadName to BSON record

### DIFF
--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -41,9 +41,11 @@ class MongoFormatter(logging.Formatter):
             'timestamp': Timestamp(int(record.created), int(record.msecs)),
             'level': record.levelname,
             'thread': record.thread,
+            'threadName': record.threadName,
             'message': record.getMessage(),
             'loggerName': record.name,
             'fileName': record.pathname,
+            'module': record.module,
             'method': record.funcName,
             'lineNumber': record.lineno
         }


### PR DESCRIPTION
Simply adding the LogRecord module and threadName fields to the BSON record.  Slightly more string data but valuable in many cases for context.
