### PR TITLE
Fix MongoHandler.collection not set on _connect if collection is capped and exists

### DIFF
--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -107,7 +107,8 @@ class MongoHandler(logging.Handler):
             try: # We don't want to override the capped collection (and it throws an error anyway)
                 self.collection = Collection(self.db, self.collection_name, capped=True, max=self.capped_max, size=self.capped_size)
             except OperationFailure:
-                pass
+                # capped collection exists, so get it
+                self.collection = self.db[self.collection_name]
         else:
             self.collection = self.db[self.collection_name]
 


### PR DESCRIPTION
When the handler tries to connect to mongo a get a collection, if the collection is capped and exists already, an OperationalFailure will be thrown, and the collection will not be set on the handler, leading to no inserts.
