### PR TITLE
Enable reusing of mongodb connection for multiple hanlders

### DIFF
--- a/log4mongo/__init__.py
+++ b/log4mongo/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 __author__ = u'Vladimír Gorej <gorej@codescale.net>'
-__version__ = '1.4.1'
+__version__ = '1.4.2'

--- a/log4mongo/__init__.py
+++ b/log4mongo/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 __author__ = u'Vladimír Gorej <gorej@codescale.net>'
-__version__ = '1.4.2'
+__version__ = '1.4.3'

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -80,10 +80,15 @@ class MongoFormatter(logging.Formatter):
 
 class MongoHandler(logging.Handler):
 
-    def __init__(self, level=logging.NOTSET, host='localhost', port=27017, database_name='logs', collection='logs',
-                 username=None, password=None, fail_silently=False, formatter=None, capped=False,
-                 capped_max=1000, capped_size=1000000, **options):
-        """Setting up mongo handler, initializing mongo database connection via pymongo."""
+    def __init__(self, level=logging.NOTSET, host='localhost', port=27017,
+                 database_name='logs', collection='logs',
+                 username=None, password=None, fail_silently=False,
+                 formatter=None, capped=False,
+                 capped_max=1000, capped_size=1000000, **kwargs):
+        """
+        Setting up mongo handler, initializing mongo database connection via
+        pymongo.
+        """
         logging.Handler.__init__(self, level)
         self.host = host
         self.port = port

--- a/log4mongo/test/test_handlers.py
+++ b/log4mongo/test/test_handlers.py
@@ -1,4 +1,5 @@
 from log4mongo.handlers import MongoHandler
+import log4mongo.handlers
 from pymongo.errors import PyMongoError
 import pymongo
 if pymongo.version_tuple[0] >= 3:
@@ -43,6 +44,7 @@ class TestMongoHandler(unittest.TestCase):
         handler.close()
 
     def test_1_connect_failed(self):
+        log4mongo.handlers._connection = None
         kwargs = {'connectTimeoutMS': 2000, 'serverselectiontimeoutms': 2000}
         if pymongo.version_tuple[0] < 3:
             with self.assertRaises(PyMongoError):
@@ -58,6 +60,7 @@ class TestMongoHandler(unittest.TestCase):
                              **kwargs)
 
     def test_connect_failed_silent(self):
+        log4mongo.handlers._connection = None
         kwargs = {'connectTimeoutMS': 2000, 'serverselectiontimeoutms': 2000}
         handler = MongoHandler(host='unknow_host',
                                database_name=self.database_name,


### PR DESCRIPTION
Added option to reuse connections. 

If reuse is set to false every handler will have it's own MongoClient. 
This could hammer down your MongoDB instance, but you can still use this  option. 

The default is True. As such a program with multiple handlers that log to mongodb will have those handlers share a single connection  to MongoDB.
