### PR TITLE
BufferedMongoHandler - New handler with buffered writes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,63 @@ This behaviour is disabled by default. You can enable this behaviour in construc
  handler = MongoHandler(host='localhost', capped=True)
 
 
+Buffered handler
+----------------
+
+BufferedMongoHandler is a subclass of MongoHandler allowing to buffer log messages
+ and write them all at once to the database. The goal is to avoid too many writes to the database, thus avoiding
+ too frequent write-locks.
+Log message buffer flush happens when the buffer is full, when a critical log message is emitted, and also periodically.
+An early buffer flush can happen when a critical message is emitted.
+And in order to avoid messages to stay indefinitively in the buffer queue before appearing in database, a periodical
+ flush happens every X seconds.
+
+This periodical flush can also be deactivated with *buffer_periodical_flush_timing=False*,
+ thus avoiding the timer thread to be created.
+
+Buffer size is configurable, as well as the log level for early flush (default is CRITICAL).
+::
+
+ import logging
+ from log4mongo.handlers import BufferedMongoHandler
+
+ handler = BufferedMongoHandler(host='localhost',                          # All usual MongoHandler parameters are valid
+                                capped=True,
+                                buffer_size=100,                           # buffer size.
+                                buffer_periodical_flush_timing=10.0,       # periodical flush every 10 seconds
+                                buffer_early_flush_level=logging.CRITICAL) # early flush level
+
+ logger = logging.getLogger().addHandler(handler)
+
+
+Example using full function signature
+-------------------------------------
+Here is an example call with all parameters filled:
+::
+
+ import logging
+ from log4mongo.handlers import MongoHandler
+
+ handler = MongoHandler(
+     level=logging.INFO,
+     host='localhost',
+     port=27017,
+     database_name='my_database',
+     collection='logs',
+     username='my_user',
+     password='my_password',
+     authentication_db='admin',
+     fail_silently=False,
+     formatter=None,
+     capped=False,
+     capped_max=1000,
+     capped_size=1000000,
+     reuse=True,
+ )
+
+ logger = logging.getLogger().addHandler(handler)
+
+
 Tests
 -----
 

--- a/log4mongo/__init__.py
+++ b/log4mongo/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 __author__ = u'Vladimír Gorej <gorej@codescale.net>'
-__version__ = '1.5.0'
+__version__ = '1.6.0'

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -12,8 +12,10 @@ import pymongo
 if pymongo.version_tuple[0] >= 3:
     from pymongo.errors import ServerSelectionTimeoutError
     write_method = 'insert_one'
+    write_many_method = 'insert_many'
 else:
     write_method = 'save'
+    write_many_method = 'insert'
 
 """
 Example format of generated bson document:
@@ -188,3 +190,126 @@ class MongoHandler(logging.Handler):
 
     def __exit__(self, type, value, traceback):
         self.close()
+
+
+class BufferedMongoHandler(MongoHandler):
+
+    def __init__(self, level=logging.NOTSET, host='localhost', port=27017,
+                 database_name='logs', collection='logs',
+                 username=None, password=None, authentication_db='admin',
+                 fail_silently=False, formatter=None, capped=False,
+                 capped_max=1000, capped_size=1000000, reuse=True,
+                 buffer_size=100, buffer_periodical_flush_timing=5.0,
+                 buffer_early_flush_level=logging.CRITICAL, **kwargs):
+        """
+        Setting up buffered mongo handler, initializing mongo database connection via
+        pymongo.
+
+        This subclass aims to provide buffering mechanism to avoid hammering the database server and
+        write-locking the database too often (even if mongo is performant in that matter).
+
+        If buffer_periodical_flush_timer is set to None or 0, no periodical flush of the buffer will be done.
+        It means that buffered messages might be stuck here for a while until the buffer full or
+        a critical message is sent (both causing flush).
+
+        If buffer_periodical_flush_timer is set to numeric value, a thread with timer will be launched
+        to call the buffer flush periodically.
+        """
+
+        MongoHandler.__init__(self, level=level, host=host, port=port, database_name=database_name, collection=collection,
+                              username=username, password=password, authentication_db=authentication_db,
+                              fail_silently=fail_silently, formatter=formatter, capped=capped, capped_max=capped_max,
+                              capped_size=capped_size, reuse=reuse, **kwargs)
+        self.buffer = []
+        self.buffer_size = buffer_size
+        self.buffer_periodical_flush_timing = buffer_periodical_flush_timing
+        self.buffer_early_flush_level = buffer_early_flush_level
+        self.last_record = None #kept for handling the error on flush
+
+        self._buffer_lock = None
+        self._timer_stopper = None
+
+        # setup periodical flush
+        if self.buffer_periodical_flush_timing:
+
+            # clean exit event
+            import atexit
+            atexit.register(self.destroy)
+
+            # retrieving main thread as a safety
+            import threading
+            main_thead = threading.current_thread()
+            self._buffer_lock = threading.RLock()
+
+            # call at interval function
+            def call_repeatedly(interval, func, *args):
+                stopped = threading.Event()
+
+                # actual thread function
+                def loop():
+                    while not stopped.wait(interval) and main_thead.is_alive():  # the first call is in `interval` secs
+                        func(*args)
+
+                threading.Thread(target=loop, daemon=True).start()
+                return stopped.set
+
+            # launch thread
+            self._timer_stopper = call_repeatedly(self.buffer_periodical_flush_timing, self.flush_to_mongo)
+
+    def emit(self, record):
+        """Inserting new logging record to buffer and flush if necessary."""
+
+        self.add_to_buffer(record)
+
+        if len(self.buffer) >= self.buffer_size or record.levelno >= self.buffer_early_flush_level:
+            self.flush_to_mongo()
+        return
+
+    def buffer_lock_acquire(self):
+        """Acquire lock on buffer (only if periodical flush is set)."""
+        if self._buffer_lock:
+            self._buffer_lock.acquire()
+
+    def buffer_lock_release(self):
+        """Release lock on buffer (only if periodical flush is set)."""
+        if self._buffer_lock:
+            self._buffer_lock.release()
+
+    def add_to_buffer(self, record):
+        """Add a formatted record to buffer."""
+
+        self.buffer_lock_acquire()
+
+        self.last_record = record
+        self.buffer.append(self.format(record))
+
+        self.buffer_lock_release()
+
+    def flush_to_mongo(self):
+        """Flush all records to mongo database."""
+        if self.collection is not None and len(self.buffer) > 0:
+            self.buffer_lock_acquire()
+            try:
+
+                getattr(self.collection, write_many_method)(self.buffer)
+                self.empty_buffer()
+
+            except Exception as e:
+                if not self.fail_silently:
+                    self.handleError(self.last_record) #handling the error on flush
+            finally:
+                self.buffer_lock_release()
+
+    def empty_buffer(self):
+        """Empty the buffer list."""
+        del self.buffer
+        self.buffer = []
+
+    def destroy(self):
+        """Clean quit logging. Flush buffer. Stop the periodical thread if needed."""
+        if self._timer_stopper:
+            self._timer_stopper()
+        self.flush_to_mongo()
+        self.close()
+
+

--- a/log4mongo/test/test_handlers.py
+++ b/log4mongo/test/test_handlers.py
@@ -1,4 +1,4 @@
-from log4mongo.handlers import MongoHandler, write_method
+from log4mongo.handlers import BufferedMongoHandler, MongoHandler, write_method, write_many_method
 import log4mongo.handlers
 from pymongo.errors import PyMongoError
 import pymongo
@@ -12,6 +12,7 @@ except ImportError:
 
 import unittest
 import logging
+import time
 import sys
 
 
@@ -197,3 +198,169 @@ class TestCappedMongoHandler(TestMongoHandler):
         document = handler.collection.find_one({'message': 'test message', 'level': 'WARNING'})
         self.assertEqual(document['message'], 'test message')
         self.assertEqual(document['level'], 'WARNING')
+
+
+class TestBufferedMongoHandler(TestMongoHandler):
+    collection_name = 'buffered_logs_test'
+
+    def setUp(self):
+        self.handler = BufferedMongoHandler(host=self.host_name,
+                                    database_name=self.database_name,
+                                    collection=self.collection_name,
+                                    buffer_size=5, buffer_periodical_flush_timing=None,
+                                    buffer_early_flush_level=logging.CRITICAL
+                                    )
+        self.log = logging.getLogger('testLogger')
+        self.log.setLevel(logging.DEBUG)
+        self.log.addHandler(self.handler)
+        self.old_stderr = sys.stdout
+        sys.stderr = StringIO()
+
+    def force_flush(self):
+        self.handler.flush_to_mongo()
+
+    def test_contextual_info(self):
+        self.log.info('test message with contextual info',
+                      extra={'ip': '127.0.0.1', 'host': 'localhost'})
+        self.force_flush()
+        document = self.handler.collection.find_one(
+            {'message': 'test message with contextual info', 'level': 'INFO'})
+        self.assertEqual(document['message'],
+                         'test message with contextual info')
+        self.assertEqual(document['level'], 'INFO')
+        self.assertEqual(document['ip'], '127.0.0.1')
+        self.assertEqual(document['host'], 'localhost')
+
+    def test_contextual_info_adapter(self):
+        adapter = logging.LoggerAdapter(self.log,
+                                        {'ip': '127.0.0.1',
+                                         'host': 'localhost'})
+        adapter.info('test message with contextual info')
+        self.force_flush()
+        document = self.handler.collection.find_one(
+            {'message': 'test message with contextual info', 'level': 'INFO'})
+        self.assertEqual(document['message'], 'test message with contextual info')
+        self.assertEqual(document['level'], 'INFO')
+        self.assertEqual(document['ip'], '127.0.0.1')
+        self.assertEqual(document['host'], 'localhost')
+
+    def test_emit(self):
+        self.log.warning('test message')
+        self.force_flush()
+        document = self.handler.collection.find_one(
+            {'message': 'test message', 'level': 'WARNING'})
+        self.assertEqual(document['message'], 'test message')
+        self.assertEqual(document['level'], 'WARNING')
+
+    def test_emit_exception(self):
+        try:
+            raise Exception('exc1')
+        except:
+            self.log.exception('test message')
+        self.force_flush()
+
+        document = self.handler.collection.find_one(
+            {'message': 'test message', 'level': 'ERROR'})
+        self.assertEqual(document['message'], 'test message')
+        self.assertEqual(document['level'], 'ERROR')
+        self.assertEqual(document['exception']['message'], 'exc1')
+
+    def test_emit_fail(self):
+        self.handler.collection = ''
+        self.log.warn('test warning')
+        self.force_flush()
+        val = sys.stderr.getvalue()
+        self.assertRegexpMatches(val, r"AttributeError: 'str' object has no attribute '{}'".format(write_many_method))
+
+    def test_buffer(self):
+        self.force_flush()
+        self.assertEqual(len(self.handler.buffer), 0, "Ensure buffer should be empty")
+
+        self.log.warning('test_buffer message')
+
+        document = self.handler.collection.find_one({'message': 'test_buffer message'})
+        self.assertIsNone(document, "Should not have been written to database")
+        self.assertEqual(len(self.handler.buffer), 1, "Buffer size should be 1")
+
+        self.log.info('test_buffer message')
+        self.log.debug('test_buffer message')
+        self.log.info('test_buffer message')
+
+        doc_amount = self.handler.collection.find({'message': 'test_buffer message'}).count()
+        self.assertEqual(doc_amount, 0, "Nothing should have been written to database")
+        self.assertEqual(len(self.handler.buffer), 4, "Buffer size should be 4")
+
+        self.log.warning('test_buffer message')
+
+        doc_amount = self.handler.collection.find({'message': 'test_buffer message'}).count()
+
+        self.assertEqual(doc_amount, 5, "Buffer size reached, buffer should have been written to database")
+        self.assertEqual(len(self.handler.buffer), 0, "Ensure buffer should be empty")
+
+        self.log.warning('test_buffer message 2')
+
+        document = self.handler.collection.find_one({'message': 'test_buffer message 2'})
+        self.assertIsNone(document, 'Should not have been written to database')
+        self.assertEqual(len(self.handler.buffer), 1, "Buffer size should be 1")
+
+    def test_buffer_early_flush(self):
+        self.force_flush()
+        self.assertEqual(len(self.handler.buffer), 0, "Ensure buffer should be empty")
+
+        self.log.info('test_buffer_early_flush message')
+
+        document = self.handler.collection.find_one({'message': 'test_buffer_early_flush message'})
+        self.assertIsNone(document, "Should not have been written to database")
+        self.assertEqual(len(self.handler.buffer), 1, "Buffer size should be 1")
+
+        self.log.critical('test_buffer_early_flush message')
+        doc_amount = self.handler.collection.find({'message': 'test_buffer_early_flush message'}).count()
+        self.assertEqual(doc_amount, 2, "2 messages should have been written to database")
+        self.assertEqual(len(self.handler.buffer), 0, "Buffer should now be empty")
+
+        doc_amount = self.handler.collection.find({'message': 'test_buffer_early_flush message',
+                                                     'level': 'INFO'}).count()
+        self.assertEqual(doc_amount, 1, "One INFO message should have been written to database")
+
+        doc_amount = self.handler.collection.find({'message': 'test_buffer_early_flush message',
+                                                     'level': 'CRITICAL'}).count()
+        self.assertEqual(doc_amount, 1, "One CRITICAL message should have been written to database")
+
+    def test_buffer_periodical_flush(self):
+
+        # Creating capped handler
+        self.handler_periodical = BufferedMongoHandler(host=self.host_name,
+                                                       database_name=self.database_name,
+                                                       collection=self.collection_name,
+                                                       buffer_size=5, buffer_periodical_flush_timing=2.0,
+                                                       buffer_early_flush_level=logging.CRITICAL)
+        self.log.removeHandler(self.handler)
+        self.log.addHandler(self.handler_periodical)
+
+        self.log.info('test periodical buffer')
+        document = self.handler_periodical.collection.find_one({'message': 'test periodical buffer'})
+        self.assertIsNone(document, "Should not have been written to database")  # except if your computer is really slow
+        self.assertEqual(len(self.handler_periodical.buffer), 1, "Buffer size should be 1")
+
+        self.log.info('test periodical buffer')
+        document = self.handler_periodical.collection.find_one({'message': 'test periodical buffer'})
+        self.assertIsNone(document, "Should not have been written to database")
+        self.assertEqual(len(self.handler_periodical.buffer), 2, "Buffer size should be 2")
+
+        time.sleep(2.5)  # wait a bit so the periodical timer thread has kicked off the buffer flush
+
+        document = self.handler_periodical.collection.find_one({'message': 'test periodical buffer'})
+        self.assertIsNotNone(document, "Should not have been written to database")
+        doc_amount = self.handler_periodical.collection.find({'message': 'test periodical buffer'}).count()
+        self.assertEqual(doc_amount, 2, "Should have found 2 documents written to database")
+        self.assertEqual(len(self.handler_periodical.buffer), 0, "Buffer should be empty")
+
+        self.assertTrue(self.handler_periodical.buffer_timer_thread.is_alive())
+        self.handler_periodical.destroy()
+        time.sleep(0.2)  # waiting a tiny bit so that the child thread actually exits
+        self.assertFalse(self.handler_periodical.buffer_timer_thread.is_alive(),
+                         "Child timer thread should be dead by now. Slow computer?")
+
+        # reset to previous
+        self.log.removeHandler(self.handler_periodical)
+        self.log.addHandler(self.handler)


### PR DESCRIPTION
Hi!
As discussed by email, I managed to pull some time to write the **buffered mongo handler** we were talking about (=>https://github.com/log4mongo/log4mongo-python/issues/21)
Here is a first version that is working for me since yesterday.
It is not yet heavily tested but it stays simple so there should not be many problems.
The only complexity resides in the thread usage for the periodical (timer) flush of the buffer. usage of such timer is fully optional.
Available to discuss this further with you if needed.
Many thanks in advance.
Cheers!
Ronan