### PR TITLE
[#31] Change is_locked to is_primary at connection verification

### DIFF
--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -142,7 +142,7 @@ class MongoHandler(logging.Handler):
                 self.connection = Connection(host=self.host, port=self.port,
                                              **kwargs)
                 try:
-                    self.connection.is_locked
+                    self.connection.is_primary
                 except ServerSelectionTimeoutError:
                     if self.fail_silently:
                         return


### PR DESCRIPTION
A fix for https://github.com/log4mongo/log4mongo-python/issues/31