### PR TITLE
Fix thread's daemon parameter

### DIFF
--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -251,7 +251,8 @@ class BufferedMongoHandler(MongoHandler):
                     while not stopped.wait(interval) and main_thead.is_alive():  # the first call is in `interval` secs
                         func(*args)
 
-                timer_thread = threading.Thread(target=loop, daemon=True)
+                timer_thread = threading.Thread(target=loop)
+                timer_thread.daemon = True
                 timer_thread.start()
                 return stopped.set, timer_thread
 


### PR DESCRIPTION
The Thread class for Python<3.3 does not have a daemon parameter in its constructor (as reported in this issue: https://github.com/log4mongo/log4mongo-python/issues/30). A quick fix to set it after instantiation via properties.