### PR TITLE
Remove main_thread from handlers.py

### DIFF
--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -237,9 +237,7 @@ class BufferedMongoHandler(MongoHandler):
             import atexit
             atexit.register(self.destroy)
 
-            # retrieving main thread as a safety
             import threading
-            main_thead = threading.current_thread()
             self._buffer_lock = threading.RLock()
 
             # call at interval function
@@ -248,7 +246,7 @@ class BufferedMongoHandler(MongoHandler):
 
                 # actual thread function
                 def loop():
-                    while not stopped.wait(interval) and main_thead.is_alive():  # the first call is in `interval` secs
+                    while not stopped.wait(interval):  # the first call is in `interval` secs
                         func(*args)
 
                 timer_thread = threading.Thread(target=loop)


### PR DESCRIPTION
Removal of the main_thread liveness check is neccessary because if the
BufferedMongoHandler is initialized in a thread that is not alive for
the whole runtime of the script, flushing using the
buffer_periodical_flush_timing does not work.

Fixes #42