### PR TITLE
Cleanup

### DIFF
--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -241,7 +241,6 @@ class BufferedMongoHandler(MongoHandler):
 
         if len(self.buffer) >= self.buffer_size or record.levelno >= self.buffer_early_flush_level:
             self.flush_to_mongo()
-        return
 
     def buffer_lock_acquire(self):
         """Acquire lock on buffer (only if periodical flush is set)."""

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -248,11 +248,9 @@ class BufferedMongoHandler(MongoHandler):
         if self.collection is not None and len(self.buffer) > 0:
             with self.buffer_lock:
                 try:
-
                     self.collection.insert_many(self.buffer)
                     self.empty_buffer()
-
-                except Exception as e:
+                except Exception:
                     if not self.fail_silently:
                         self.handleError(self.last_record) #handling the error on flush
 

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -290,5 +290,3 @@ class BufferedMongoHandler(MongoHandler):
             self._timer_stopper()
         self.flush_to_mongo()
         self.close()
-
-

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -5,7 +5,6 @@ import threading
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.errors import OperationFailure
-from pymongo.errors import PyMongoError
 from pymongo.errors import ServerSelectionTimeoutError
 
 """

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import logging
+import threading
 
 from pymongo import MongoClient
 from pymongo.collection import Collection
@@ -215,7 +216,6 @@ class BufferedMongoHandler(MongoHandler):
             import atexit
             atexit.register(self.destroy)
 
-            import threading
             self._buffer_lock = threading.RLock()
 
             # call at interval function

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -236,17 +236,12 @@ class BufferedMongoHandler(MongoHandler):
     def emit(self, record):
         """Inserting new logging record to buffer and flush if necessary."""
 
-        self.add_to_buffer(record)
-
-        if len(self.buffer) >= self.buffer_size or record.levelno >= self.buffer_early_flush_level:
-            self.flush_to_mongo()
-
-    def add_to_buffer(self, record):
-        """Add a formatted record to buffer."""
-
         with self.buffer_lock:
             self.last_record = record
             self.buffer.append(self.format(record))
+
+        if len(self.buffer) >= self.buffer_size or record.levelno >= self.buffer_early_flush_level:
+            self.flush_to_mongo()
 
     def flush_to_mongo(self):
         """Flush all records to mongo database."""

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,15 +1,15 @@
-from log4mongo.handlers import BufferedMongoHandler
-from log4mongo.handlers import MongoHandler
-
-import log4mongo.handlers
-from pymongo.errors import ServerSelectionTimeoutError
-
 from io import StringIO
 import unittest
 import logging
 import time
 import sys
 import threading
+
+from pymongo.errors import ServerSelectionTimeoutError
+
+import log4mongo.handlers
+from log4mongo.handlers import BufferedMongoHandler
+from log4mongo.handlers import MongoHandler
 
 
 class TestMongoHandler(unittest.TestCase):


### PR DESCRIPTION
    
    * Remove unnecessary small methods
    * Always import threading module (Avoid local import)
    * Always instantiate buffer_lock object even if periodical flush is
      disabled. Once we drop support for py3.6 we can use
      contextlib.null_context in the case of disabled periodical flushing.
