### PR TITLE
Updated for compatibility with pymongo 4.0+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ log4mongo-python is using pymongo driver - http://github.com/mongodb/mongo-pytho
 Requirements
 ------------
 
-- python 3.6+
-- pymongo 3.9+
+- python 3.6.2+
+- pymongo 4.0+
 - mongo database
 
 For more information see *debian_requirements.txt* and *requirements.txt* files.

--- a/log4mongo/handlers.py
+++ b/log4mongo/handlers.py
@@ -246,23 +246,14 @@ class BufferedMongoHandler(MongoHandler):
 
     def flush_to_mongo(self):
         """Flush all records to mongo database."""
-
-        # we have to acquire buffer lock already for the check. otherwise, its state can change
-        with self.buffer_lock:
-            if self.collection is not None and len(self.buffer) > 0:
+        if self.collection is not None and len(self.buffer) > 0:
+            with self.buffer_lock:
                 try:
                     self.collection.insert_many(self.buffer)
                     self.empty_buffer()
-                except Exception as _:
-                    # try to insert one-by-one and catch exception. this is from MH
-                    for msg in self.buffer:
-                        try:
-                            self.collection.insert_one(msg)
-                        except Exception as _:
-                            if msg['levelname'] != 'DEBUG':
-                                print(f'flush_to_mongo failed with\n{msg}')
-                    # clear buffer now
-                    self.empty_buffer()
+                except Exception:
+                    if not self.fail_silently:
+                        self.handleError(self.last_record) #handling the error on flush
 
     def empty_buffer(self):
         """Empty the buffer list."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo>=3.9
+pymongo>=4.0


### PR DESCRIPTION
Tested on mongodb 6.0.1 and pymongo 4.3.3, should be compatible starting 5.0.0+ and 4.0 respectively. Tested on a DB with authentication enabled but it should work without too hopefully.

- Fixed type error when comparing value of attribute type level.
- Moved authentication to MongoClient().

Quick disclaimer: I'm a total 0 with Python. Not going to lie, those are hot glued fixes until my debugger stopped turning red, I'm certain there's a better way to do things but at least it runs without crashing from my limited testing. Some of the methods and ways of doing things got changed when going from 4.0 to 5.0 like the way connections/clients are handled so I made some quick change to make it at least run. 
From what I understood, we shouldn't manage multiple connections from from one MongoClient anymore, methods like authenticate(), logout() and close() have been removed from the pymongo library, there's no connecting and disconnecting to do, authentication is done on the MongoClient object so I moved authentication there.
Close() shouldn't be of any use now I think? I just None-d and false-d the relevant variables for now.